### PR TITLE
🔧 chore: semantic-releaseの自動リリースがブランチ保護で止まる問題の解消

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,27 +7,38 @@ on:
 
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
-    permissions: write-all  # tag・release・commit に必要
     steps:
+      # ブランチ保護を回避するため GitHub App を利用
+      # 参考：https://zenn.dev/wakamsha/articles/semantic-release-and-protected-branches
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SEM_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEM_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      # pnpm をインストール（Corepack でも良いが、Action の方が確実）
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 10             # pnpm のバージョン
-          run_install: false      # 依存関係のインストールは後で実行
+          version: 10
+          run_install: false
 
-      # Node をセットアップ（pnpm 用キャッシュを有効化）
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '23'      # LTS
+          node-version: '23'
           cache: 'pnpm'           # pnpm-lock.yaml をキーに自動キャッシュ
+
+      - name: pnpm audit
+        run: pnpm audit
 
       # prepare スクリプトを無視して依存関係だけ取得
       - name: Install dependencies (skip prepare)
@@ -37,4 +48,4 @@ jobs:
       - name: Release
         run: pnpm exec semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
GitHub Appを挟むことでsemantic-releaseの自動リリースがブランチ保護で止まる問題を解消した